### PR TITLE
fix: allow unreachable peers to be retried

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2427,12 +2427,6 @@ namespace connect_helpers
 /* is this atom someone that we'd want to initiate a connection to? */
 [[nodiscard]] bool is_peer_candidate(tr_torrent const* tor, tr_peer_info const& peer_info, time_t const now)
 {
-    // have we already tried and failed to connect?
-    if (auto const conn = peer_info.is_connectable(); conn && !*conn)
-    {
-        return false;
-    }
-
     // not if we're both seeds
     if (tor->is_done() && peer_info.is_seed())
     {


### PR DESCRIPTION
`tr_peer_info::reconnect_interval_has_passed()` contains logic to increase the reconnect interval for unreachable peers, but it has no effect at all currently because they wouldn't be tried in the first place.